### PR TITLE
pause the park when loading directly into park

### DIFF
--- a/src/ParkPauser.js
+++ b/src/ParkPauser.js
@@ -231,6 +231,7 @@ function openWindow() {
 function main() {
     getSavedSettings();
     createWidgets();
+    onParkLoad();
     context.subscribe("map.changed",onParkLoad)
     context.subscribe("map.save",onParkSave)
 


### PR DESCRIPTION
Checks the current state of the game when the plugin initializes. Fixes #1 